### PR TITLE
🚨  Fix security scanning for `CVE-2022-42969`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,4 +91,5 @@ wheel = {[base_configs]wheel}
 [testenv:security]
 skip_install = true
 deps = safety
-commands = safety check --full-report -r {toxinidir}/requirements-all.txt
+commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
+    --ignore=51457 # CVE-2022-42969


### PR DESCRIPTION
Must follow this up by removing dependence on transitive dependencies:
```shell
❯ poetry show py
name         : py
version      : 1.11.0
description  : library with cross-python path, ini-parsing, io, code, log facilities

required by
- pytest-forked *
- pyzmq *
- tox >=1.4.17
```

Note:
  - `pytest-forked` removed as of tox `3.0.0`
  - tox does not use affected part of the library, and 4.0 will remove py dependency completely.