### PR TITLE
🔧 Bump Codecov coverage target to 100

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: "0"
+        target: "100"
     project:
       default:
-        target: "0"
+        target: "100"


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

To align with the project's global code test coverage target.