### PR TITLE
Revert "💚  Fix `codecov-action` 4.0 breaking change: specifying upload tokens as an env var"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,10 +189,9 @@ jobs:
         if: "contains(matrix.os, env.USING_COVERAGE_OS) &&
              contains(matrix.python-version, env.USING_COVERAGE_PY_VER)"
         uses: "codecov/codecov-action@v4.0.1"
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./.tox/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   # Documentation build testing jobs ------------------------


### PR DESCRIPTION
Reverts TeoZosa/pytudes#645