### PR TITLE
🔧  Remove redundant Poetry documentation `dev-dependencies`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,18 +31,6 @@ pydantic = "^2.6"
 scikit-learn = "^1.4.0"
 scipy = "^1.12.0"
 
-# Documentation
-emoji = { version = "^2.10.1", optional = true}
-importlib-metadata = { version = "^4.13.0", optional = true}
-myst-parser = { version = "^1.0.0", optional = true}
-pygments = { version = "^2.17.2", optional = true}
-python-dotenv = { version = "^0.21.0", optional = true}
-sphinx = { version = "^6.2.1", optional = true}
-sphinx-autoapi = { version = "^2.1.1", optional = true}
-sphinx-rtd-theme = { version = "^2.0.0", optional = true}
-sphinxcontrib-confluencebuilder = { version = "^2.4.0", optional = true}
-types-emoji = { version = "^2.1.0", optional = true} # PEP 561 compliant stub package for mypy
-
 [tool.poetry.dev-dependencies]
 # Standardized Developer Workflow Orchestration
 cruft = "^2.11.1" # Automated Cookiecutter template synchronization


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

Resolves dependency conflicts. 
- Should have been removed in 00340176af07ebbfd82d37d05302de464d322ca1